### PR TITLE
Fix parsing of `&comments`

### DIFF
--- a/pythonx/vimsnippets.py
+++ b/pythonx/vimsnippets.py
@@ -32,7 +32,7 @@ def _parse_comments(s):
             flags, text = next(i).split(':', 1)
 
             if len(flags) == 0:
-                rv.append((text, text, text, ""))
+                rv.append(('OTHER', text, text, text, ""))
             # parse 3-part comment, but ignore those with O flag
             elif 's' in flags and 'O' not in flags:
                 ctriple = ["TRIPLE"]


### PR DESCRIPTION
This fixes a crash where comment formats should have a description pre-prended to them. This occurred using `bbox` in Julia, where `&comments` is `:#`. and `&commentstring` is `#=%s=#`. This fix allows bboxes to be drawn for me, by ensuring that the comment structure **always** has a type pre-pended, which is removed on L76/77.

The traceback below shows the original issue, caused by L77 removing the first of the four comment definitions from the tuple.

```
An error occured. This is either a bug in UltiSnips or a bug in a
snippet definition. If you think this is a bug, please report it to
https://github.com/SirVer/ultisnips/issues/new.

Following is the full stack trace:
Traceback (most recent call last):
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/err_to_scratch_buffer.py", line 16, in wrapper
    return func(self, *args, **kwds)
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 124, in expand
    if not self._try_expand():
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 718, in _try_expand
    self._do_snippet(snippet, before)
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet_manager.py", line 673, in _do_snippet
    None, start, end)
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/snippet/definition/_base.py", line 442, in launch
    snippet_instance.update_textobjects()
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/text_objects/_snippet_instance.py", line 80, in update_textobjects
    if obj._update(done):
  File "/home/kevin/.vim/bundle/ultisnips/pythonx/UltiSnips/text_objects/_python_code.py", line 308, in _update
    exec(code, self._locals)  # pylint:disable=exec-used
  File "<string>", line 4, in <module>
  File "/home/kevin/.vim/bundle/vim-snippets/pythonx/vimsnippets.py", line 81, in make_box
    b, m, e, i = (s.strip() for s in get_comment_format())
ValueError: not enough values to unpack (expected 4, got 3)

Executed snippet code: 
  1
  2   if not snip.c:
  3       width = int(vim.eval("&textwidth - (virtcol('.') == 1 ? 0 : virtcol('.'))")) or 71
  4   box = make_box(len(t[1]), width)
  5   snip.rv = box[0]
```
